### PR TITLE
adds two env variables to force atrain flatpak to stop qt fallback

### DIFF
--- a/flatpak/run-atrain.sh
+++ b/flatpak/run-atrain.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -eo pipefail
 
+# Workaround for WebKitGTK sandbox graphics driver/GBM issues (especially on NVIDIA) https://github.com/aTrainTranscription/aTrain/issues/151#issuecomment-4901338674
+export WEBKIT_DISABLE_DMABUF_RENDERER=1
+# Force pywebview to use GTK directly and avoid loading warnings for QT
+export PYWEBVIEW_GUI=gtk
+
 required_models_present() {
     if [[ -n "${REQUIRED_MODEL_1:-}" && -n "${REQUIRED_MODEL_2:-}" ]]; then
         [[ -d "${REQUIRED_MODEL_1}" && -d "${REQUIRED_MODEL_2}" ]]


### PR DESCRIPTION


## Summary

A user reported issues starting aTrain flatpak under newer Ubuntu versions. This pull request adds the env variables

```
# Workaround for WebKitGTK sandbox graphics driver/GBM issues (especially on NVIDIA) https://github.com/aTrainTranscription/aTrain/issues/151#issuecomment-4901338674
export WEBKIT_DISABLE_DMABUF_RENDERER=1
# Force pywebview to use GTK directly and avoid loading warnings for QT
export PYWEBVIEW_GUI=gtk
```

The env variables are added to run-atrain.sh which the flatpak uses for launching aTrain.

The first avoids pywebview not loading and the second to explicitly use GTK as intended.

## References

Closes https://github.com/aTrainTranscription/aTrain/issues/151


## Verification Steps

Affected user added the env flags to the start command on his machine which resolved the issues.

Testing locally on mine which did not have those issues shows aTrain flatpak still running with those env variables. 