### PR TITLE
fix: gui cuda error on linux

### DIFF
--- a/aTrain/app.py
+++ b/aTrain/app.py
@@ -1,3 +1,4 @@
+import multiprocessing as mp
 import os
 import sys
 from pathlib import Path
@@ -6,6 +7,11 @@ from typing import Annotated, cast
 from aTrain_core.globals import ATRAIN_DIR, FLATPAK, REQUIRED_MODELS
 from aTrain_core.load_resources import get_model
 from typer import Option, Typer
+
+# forces linux to use spawn instead of fork, as CUDA doesn't work with fork
+# (spawn is default for Windows and Mac)
+# see: https://stackoverflow.com/questions/33748750/cuda-error-initialization-error-when-using-parallel-in-python
+mp.set_start_method("spawn", force=True)
 
 cli = Typer(help="CLI for aTrain.")
 


### PR DESCRIPTION
## Summary

It fixes the CUDA initialization error on Linux when using the GUI.

Current behavior is that transcription using GPU works perfectly fine with CLI, but errors when using the GUI.

After a lot of digging, I figured out that CUDA cannot handle changing process IDs when Linux forks a process (as the multiprocessing Python library does).
See https://stackoverflow.com/questions/33748750/cuda-error-initialization-error-when-using-parallel-in-python

To fix this issue, we have to force multiprocessing to use "spawn" on Linux as well. On Windows and Mac, "spawn" is the default behavior.

New behavior, transcription using GPU works on the GUI as well.

## References

None

## Screenshots / Examples

None

## Verification Steps

- Transcribe using GPU

## Note

I was not able to test the changes on Windows or Mac!