### PR TITLE
docs: fix the install instructions for the cu128 pin and the new org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,9 +85,9 @@ To build your own package:
 Clone and install aTrain in **editable mode**:
 
 ```bash
-git clone https://github.com/JuergenFleiss/aTrain.git
+git clone https://github.com/aTrainTranscription/aTrain.git
 cd aTrain
-pip install -e ".[gui]" --extra-index-url https://download.pytorch.org/whl/cu130
+pip install -e ".[gui]" --extra-index-url https://download.pytorch.org/whl/cu128
 ```
 
 Download ffmpeg and all required models from Whisper and pyannote.audio:

--- a/README.md
+++ b/README.md
@@ -79,19 +79,19 @@ Until aTrain ships on PyPI, install directly from the GitHub repo. Engine
 only (CLI usage):
 
 ```bash
-pip install "aTrain @ git+https://github.com/JuergenFleiss/aTrain.git"
+pip install "aTrain @ git+https://github.com/aTrainTranscription/aTrain.git"
 ```
 
 For `aTrain start` (the desktop / browser app), add the GUI extras:
 
 ```bash
-pip install "aTrain[gui] @ git+https://github.com/JuergenFleiss/aTrain.git"
+pip install "aTrain[gui] @ git+https://github.com/aTrainTranscription/aTrain.git"
 ```
 
-On Windows, prepend the PyTorch CUDA index for the `cu130` torch wheel:
+On Windows, prepend the PyTorch CUDA index for the `cu128` torch wheel:
 
 ```bash
-pip install ... --extra-index-url https://download.pytorch.org/whl/cu130
+pip install ... --extra-index-url https://download.pytorch.org/whl/cu128
 ```
 
 On Linux the PyPI torch wheel already bundles CUDA; macOS is CPU-only.

--- a/docs/installation-linux.md
+++ b/docs/installation-linux.md
@@ -54,7 +54,7 @@ source atrain_venv/bin/activate
 Install aTrain (with the GUI extras) from the GitHub repository:
 
 ```bash
-pip install "aTrain[gui] @ git+https://github.com/JuergenFleiss/aTrain.git@develop"
+pip install "aTrain[gui] @ git+https://github.com/aTrainTranscription/aTrain.git@develop"
 ```
 
 On Linux the PyPI PyTorch wheel already bundles CUDA, so no extra package index

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,7 +20,7 @@ Additional download types are listed on the
 
 ## Install from source with pip
 
-You need **Python ≥ 3.10**.
+You need **Python ≥ 3.11**.
 
 Set up and activate a virtual environment:
 
@@ -36,15 +36,15 @@ Install aTrain with the GUI extras (needed for `aTrain start`, the desktop /
 browser app):
 
 ```bash
-pip install "aTrain[gui] @ git+https://github.com/JuergenFleiss/aTrain.git"
+pip install "aTrain[gui] @ git+https://github.com/aTrainTranscription/aTrain.git"
 ```
 
 On **Windows**, prepend the PyTorch CUDA index so pip pulls the CUDA torch
 wheel:
 
 ```bash
-pip install "aTrain[gui] @ git+https://github.com/JuergenFleiss/aTrain.git" \
-    --extra-index-url https://download.pytorch.org/whl/cu130
+pip install "aTrain[gui] @ git+https://github.com/aTrainTranscription/aTrain.git" \
+    --extra-index-url https://download.pytorch.org/whl/cu128
 ```
 
 On **Linux** the PyPI torch wheel already bundles CUDA. **macOS** is CPU-only.


### PR DESCRIPTION
The documented pip install cannot resolve: the docs still point at the cu130 wheel index, but the Windows pin has been `+cu128` since #215.

Same lines: clone and install URLs updated from `JuergenFleiss/aTrain` to `aTrainTranscription/aTrain`, and `docs/installation.md` now says Python >= 3.11 to match `requires-python`.

Docs only.
