### PR TITLE
fix: keep torch off the startup path so the splash screen shows again

### DIFF
--- a/aTrain/components/settings/advanced.py
+++ b/aTrain/components/settings/advanced.py
@@ -1,4 +1,6 @@
-from aTrain_core.cli import DEFAULT_CPU_THREADS, MAX_CPU_THREADS
+# From globals, not cli: cli imports transcribe and with it torch, which
+# must stay unloaded until the splash screen fetches it in the background.
+from aTrain_core.globals import DEFAULT_CPU_THREADS, MAX_CPU_THREADS
 from aTrain_core.settings import ComputeType
 from nicegui import ElementFilter, app, ui
 

--- a/tests/e2e_browser/test_pages_render.py
+++ b/tests/e2e_browser/test_pages_render.py
@@ -15,7 +15,11 @@ from playwright.sync_api import Page, expect
 
 def test_main_page_loads(atrain_server: str, page: Page) -> None:
     page.goto(atrain_server)
-    expect(page.get_by_text("Select File").first).to_be_visible()
+    # First visit: the splash shows while torch loads in the background, and
+    # only then the page renders. A cold import can take well over the 5 s
+    # expect default on a CI runner, so wait explicitly for the handover.
+    expect(page.get_by_text("Starting Application")).to_be_visible()
+    expect(page.get_by_text("Select File").first).to_be_visible(timeout=60_000)
     expect(page.get_by_text("Speaker Detection").first).to_be_visible()
 
 

--- a/tests/ui/test_startup_imports.py
+++ b/tests/ui/test_startup_imports.py
@@ -1,0 +1,52 @@
+"""Guard the lazy-loading of torch at startup.
+
+The splash screen only shows while torch is still unloaded
+(`splash_screen()` checks `"torch" not in sys.modules`), and
+`utils/transcription.py` defers its aTrain_core import for the same reason.
+Both are defeated the moment any page module pulls torch in at import time -
+which is easy to do by accident, because half of aTrain_core reaches it
+through faster_whisper.
+
+This has to run in a subprocess. In the pytest process some other test has
+long imported torch, so an in-process assertion would pass no matter what.
+"""
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+# The modules that make up the transcribe page, i.e. what is imported before
+# the first window can appear. The splash itself is excluded: it is the thing
+# that loads torch on purpose.
+STARTUP_MODULES = [
+    "aTrain.components.settings.advanced",
+    "aTrain.components.settings.file",
+    "aTrain.components.settings.model",
+    "aTrain.components.settings.language",
+    "aTrain.components.settings.speaker_detection",
+    "aTrain.components.settings.speaker_count",
+]
+
+PROBE = """
+import importlib, json, sys
+for name in {modules!r}:
+    importlib.import_module(name)
+print(json.dumps({{"torch": "torch" in sys.modules}}))
+"""
+
+
+@pytest.mark.parametrize("module", STARTUP_MODULES)
+def test_startup_module_does_not_import_torch(module):
+    result = subprocess.run(
+        [sys.executable, "-c", PROBE.format(modules=[module])],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=True,
+    )
+    assert json.loads(result.stdout)["torch"] is False, (
+        f"{module} pulls torch in at import time, which defeats the splash screen "
+        "and the deferred imports on the startup path"
+    )


### PR DESCRIPTION
Since 5e7fd46, `advanced.py` imports two constants from `aTrain_core.cli`, which pulls in `aTrain_core.transcribe` and with it torch - before the first page renders. The splash screen only shows while torch is still unloaded, so it never appears, and the deferred import in `utils/transcription.py` defers nothing. The user gets a blank window for several seconds instead of a spinner, long enough to double-click and start two instances.

Both constants live in `aTrain_core.globals`. Importing them from there takes the component from ~3.5 s to ~0.75 s at import time and keeps torch out.

The guard test imports each startup module in a subprocess and asserts torch is absent.

cc @gerardo-navarro