### PR TITLE
ci: sign the Windows MSIX with SignPath

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,13 @@
 name: Release
 
-# Phase 1 of #212 - unsigned Windows MSIX, tag-triggered. Builds via
-# PyInstaller + makeappx.exe. The default (slim) build ships no models -
-# they download on first run (#226). Installers are distributed as
-# workflow artifacts (they exceed the 2 GiB release-asset limit, see
-# #229); the GitHub release carries the sha256 checksums and the
-# CycloneDX SBOM (#213) for verification. Signing (#211), Flatpak (needs
-# Flathub manifest refresh), and macOS DMG are follow-ups.
+# Tag-triggered Windows MSIX release (#212), Authenticode-signed via
+# SignPath (#211). Builds via PyInstaller + makeappx.exe. The default
+# (slim) build ships no models - they are fetched on first use (#226);
+# `bundle_models` bakes them in. Installers go to Zenodo (#229)
+# and stay available as workflow artifacts, since they exceed the 2 GiB
+# release-asset limit; the GitHub release carries the sha256 checksums
+# and the CycloneDX SBOM (#213) for verification. Flatpak (needs Flathub
+# manifest refresh) and macOS DMG are follow-ups.
 
 on:
   push:
@@ -25,6 +26,7 @@ on:
 
 permissions:
   contents: write  # required for `gh release create`
+  actions: read    # SignPath reads the job and downloads the artifact via the API
 
 env:
   # Pinned like every other input to the build: a new release of the generator
@@ -41,6 +43,8 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       suffix: ${{ steps.version.outputs.suffix }}
+      # Consumed by the signing step in the publish job.
+      artifact-id: ${{ steps.upload.outputs.artifact-id }}
     # Build ~13 min, plus ~13 min to push the 2.9 GB installer to Zenodo -
     # too close to the previous 30 min limit to absorb network variance.
     timeout-minutes: 60
@@ -155,6 +159,11 @@ jobs:
         # makeappx.exe expects the root of the package tree to contain
         # AppxManifest.xml + all referenced files.
         shell: bash
+        env:
+          # The subject of the signing certificate, which the Publisher has to
+          # match exactly (#211). Read from a variable rather than the shell
+          # substitution below so a name containing quotes cannot break it.
+          PUBLISHER: ${{ vars.SIGNPATH_PUBLISHER }}
         run: |
           version="${{ steps.version.outputs.version }}"
           staging="msix-staging"
@@ -167,7 +176,10 @@ jobs:
           # normalize semver-like strings (e.g. "1.5.0" -> "1.5.0.0",
           # "0.0.0-test" -> "0.0.0.0" for makeappx acceptance).
           normalized="$(echo "$version" | sed 's/-.*//' | awk -F. '{ while (NF<3) { $(NF+1)=0 }; printf "%d.%d.%d", $1, $2, $3 }')"
-          sed "s|{{VERSION}}|$normalized|g" packaging/msix/AppxManifest.xml.template > "$staging/AppxManifest.xml"
+          # Builds that skip signing (forks, no SignPath setup) get a placeholder.
+          publisher="${PUBLISHER:-CN=aTrain unsigned build}"
+          sed -e "s|{{VERSION}}|$normalized|g" -e "s|{{PUBLISHER}}|$publisher|g" \
+            packaging/msix/AppxManifest.xml.template > "$staging/AppxManifest.xml"
           echo "Manifest:"
           cat "$staging/AppxManifest.xml"
 
@@ -200,6 +212,7 @@ jobs:
       - name: Upload MSIX artifact
         # Always uploaded as workflow artifact - the only GitHub channel
         # the installers fit in (releases cap assets at 2 GiB).
+        id: upload
         uses: actions/upload-artifact@v4
         with:
           name: aTrain-msix-${{ steps.version.outputs.version }}${{ steps.version.outputs.suffix }}
@@ -221,6 +234,11 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      # Here rather than on the step: the `secrets` context is not available in
+      # a step-level `if`, the `env` one is.
+      SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+      SIGNPATH_ORG_ID: ${{ secrets.SIGNPATH_ORG_ID }}
 
     steps:
       - name: Checkout
@@ -243,6 +261,30 @@ jobs:
             "https://github.com/$GITHUB_REPOSITORY/archive/refs/tags/v$version.tar.gz"
           ls -la
 
+      - name: Sign the MSIX with SignPath
+        # Authenticode via SignPath (#211). Runs before the checksums and
+        # uploads because signing rewrites the file. The action fetches the
+        # artifact by id and extracts the signed archive over `artifacts/`,
+        # replacing the unsigned MSIX downloaded above. Skipped unless all
+        # five SignPath values are set, so forks and runs without the SignPath
+        # setup still build, just unsigned.
+        if: >-
+          env.SIGNPATH_API_TOKEN != '' && env.SIGNPATH_ORG_ID != '' &&
+          vars.SIGNPATH_PROJECT_SLUG != '' && vars.SIGNPATH_POLICY_SLUG != '' &&
+          vars.SIGNPATH_PUBLISHER != ''
+        uses: SignPath/github-action-submit-signing-request@v2.3
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ secrets.SIGNPATH_ORG_ID }}
+          # Variables, not secrets: they are identifiers, and switching from the
+          # test certificate to the production one is then a settings change
+          # rather than a code change.
+          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ vars.SIGNPATH_POLICY_SLUG }}
+          github-artifact-id: ${{ needs.build-windows-msix.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: artifacts
+
       - name: Generate sha256 checksums
         # Recomputed over the downloaded files rather than reused from the
         # build job, so the checksums also cover the artifact round-trip. One
@@ -260,8 +302,7 @@ jobs:
         # installers exceed GitHub's 2 GiB per-asset limit, so consumers fetch
         # them from Zenodo (#229) or the workflow artifact and verify them
         # against the sha256 published here. The SBOMs (#213) sit next to them,
-        # small enough to read without downloading a 2.9 GB installer first;
-        # signing material (#211) attaches to the same anchor later.
+        # small enough to read without downloading a 2.9 GB installer first.
         # Two flows are supported:
         # - release created via the GitHub UI (creates the tag on publish,
         #   which triggers this run): upload to the existing release.

--- a/packaging/msix/AppxManifest.xml.template
+++ b/packaging/msix/AppxManifest.xml.template
@@ -4,12 +4,13 @@
   workflow. `{{VERSION}}` is substituted at build time from the tag ref
   (see .github/workflows/release.yml).
 
-  Publisher is a placeholder for unsigned / sideloaded MSIX. When signing
-  is added (Phase 2, see #211), the Publisher CN must match the signing
-  certificate exactly, and the same identity must be registered with
-  Microsoft Partner Center if this MSIX is intended for MS Store
-  distribution. Do not treat this manifest as MS-Store-publishable in its
-  current form.
+  `{{PUBLISHER}}` is substituted from the `SIGNPATH_PUBLISHER` repository
+  variable and must match the subject of the signing certificate exactly,
+  or signing fails. The test and production certificates have different
+  subjects, which is why this is a variable rather than a fixed string.
+  Builds that skip signing get a placeholder. For MS Store distribution
+  the same identity would additionally have to be registered with
+  Microsoft Partner Center.
 -->
 <Package
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
@@ -19,7 +20,7 @@
 
   <Identity
     Name="aTrainTranscription.aTrain"
-    Publisher="CN=aTrain unsigned build"
+    Publisher="{{PUBLISHER}}"
     Version="{{VERSION}}.0"
     ProcessorArchitecture="x64" />
 

--- a/packaging/msix/README.md
+++ b/packaging/msix/README.md
@@ -5,27 +5,18 @@ Files that drive the Windows MSIX build in `.github/workflows/release.yml`.
 ## `AppxManifest.xml.template`
 
 Template for the package manifest. The release workflow substitutes
-`{{VERSION}}` (from the tag, e.g. `1.5.0`) and writes the concrete
+`{{VERSION}}` (from the tag, e.g. `1.5.0`) and `{{PUBLISHER}}` (from the
+`SIGNPATH_PUBLISHER` repository variable) and writes the concrete
 `AppxManifest.xml` into the PyInstaller output directory before packing
 with `makeappx.exe`.
 
-**Phase 1 (this PR) — unsigned**:
-
-- `Publisher="CN=aTrain unsigned build"` is a placeholder.
+- `Publisher` has to match the signing certificate's subject exactly, or
+  signing fails (#211). Builds that skip signing get the placeholder
+  `CN=aTrain unsigned build`; an unsigned MSIX does not install by
+  double-click on Windows.
 - MSIX is packed with `makeappx.exe pack /d dist/aTrain /p aTrain-<version>.msix`.
-- The result is **not** installable via double-click on Windows without
-  either signing or enabling developer mode + explicit trust.
-- Useful for smoke tests, download-and-inspect, and as a foundation for
-  Phase 2.
-
-**Phase 2 (future, #211)**:
-
-- `Publisher` must match the signing certificate's subject `CN=…` exactly.
 - If distributing via MS Store, the identity (`Name`, `Publisher`) must
   match what's registered in Microsoft Partner Center.
-- Recommended signing path: SignPath.io OSS Community Edition (free,
-  HSM-backed, GitHub Actions integration). See the #211 discussion for
-  the current cert-provider trade-off (Certum vs SignPath).
 
 ## Assets
 
@@ -34,4 +25,4 @@ with `makeappx.exe`.
 `Wide310x150Logo.png`). Placeholder assets are placed in
 `packaging/msix/Assets/` and copied into the PyInstaller output during
 packaging. They should be replaced with the aTrain brand marks Armin
-already has for the MS Store submission before Phase 2 ships.
+already has for the MS Store submission before the first signed release.


### PR DESCRIPTION
## Summary

Adds Authenticode signing of the Windows MSIX via SignPath (#211) to the release workflow.

- Signing runs in the publish job before checksums and uploads, since it rewrites the file. The action fetches the build artifact by id (new job output) and extracts the signed archive over `artifacts/`.
- The manifest `Publisher` now comes from the `SIGNPATH_PUBLISHER` variable. It has to match the certificate subject exactly, and the test and production certificates differ. Builds without the variable keep the old placeholder.
- The step is skipped unless all five SignPath values are set: secrets `SIGNPATH_API_TOKEN` and `SIGNPATH_ORG_ID`, variables `SIGNPATH_PROJECT_SLUG`, `SIGNPATH_POLICY_SLUG` and `SIGNPATH_PUBLISHER`. So this can be merged before they exist.
- `actions: read` is added because the action reads the job and downloads the artifact through the API.

Switching from the test to the production certificate is a change of `SIGNPATH_POLICY_SLUG` and `SIGNPATH_PUBLISHER` only.

## References

Towards #211.

## Verification Steps

- SignPath side checked by hand: a zip in the workflow's shape (MSIX, checksums, SBOM) signed on the `test-signing` policy. The MSIX came back signed, the other files unchanged.
- The action step itself needs the organisation's secrets and a tag, so the first real run is upstream: push a `v*` tag, then check the MSIX with `Get-AuthenticodeSignature`.

cc @gerardo-navarro