### PR TITLE
docs: add code signing policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ aTrain is a tool for automatically transcribing speech recordings utilizing stat
 
 aTrain is published on Flathub for Linux and the Microsoft Store for Windows.  Additional download types [can be found here](https://business-analytics.uni-graz.at/de/forschung/atrain/download/).
 
+How release builds are signed: see the [Code signing policy](docs/code-signing-policy.md).
+
 
 ## About aTrain
 
@@ -164,3 +166,5 @@ standalone executable, and the branching model. aTrain uses
 
 ## Attribution
 The GIFs and Icons in aTrain are from [tenor](https://tenor.com/) and [flaticon](https://www.flaticon.com/).
+
+Free code signing provided by [SignPath.io](https://signpath.io), certificate by [SignPath Foundation](https://signpath.org).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,3 +21,5 @@ Please add at least the following details:
 
 
 (adapted from https://github.com/openqda/openqda/edit/main/SECURITY.md)
+
+Release builds are code-signed; see the [Code signing policy](docs/code-signing-policy.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,8 @@ project overview, badges, and benchmarks, see the [main README](../README.md).
 
 - [Security](security/) — security assessments, e.g. the
   [OWASP Top 10 for LLM Applications assessment](security/owasp-llm-top10-assessment.md).
+- [Code signing policy](code-signing-policy.md) — how release builds are
+  signed, who approves signing requests, and what the app transmits.
 
 ## For contributors
 

--- a/docs/code-signing-policy.md
+++ b/docs/code-signing-policy.md
@@ -1,0 +1,49 @@
+# Code signing policy
+
+Free code signing provided by [SignPath.io](https://signpath.io), certificate by [SignPath Foundation](https://signpath.org).
+
+## What is signed
+
+- **Windows MSIX from GitHub releases and Zenodo**: Authenticode-signed through
+  SignPath.io with a certificate issued to SignPath Foundation, from v1.5.0 on.
+  Earlier builds are unsigned.
+- **Microsoft Store**: packages are signed by Microsoft as part of Store
+  publishing.
+- **Flathub**: Flatpak packages carry no Authenticode signature; integrity is
+  handled by Flathub's build and distribution infrastructure.
+
+Signing runs in the release workflow (`.github/workflows/release.yml`) on a
+tagged commit. Every signing request is approved manually by an approver
+before the certificate is applied.
+
+## Roles
+
+- **Authors** - trusted to change the source code without additional review:
+  [@JuergenFleiss](https://github.com/JuergenFleiss),
+  [@ArminHaberl](https://github.com/ArminHaberl)
+  ([merge2main team](https://github.com/orgs/aTrainTranscription/teams/merge2main)).
+- **Reviewers** - every change proposed by others is reviewed by one of them:
+  [@JuergenFleiss](https://github.com/JuergenFleiss),
+  [@ArminHaberl](https://github.com/ArminHaberl),
+  [@gerardo-navarro](https://github.com/gerardo-navarro),
+  [@BW-Projects](https://github.com/BW-Projects)
+  ([reviewers team](https://github.com/orgs/aTrainTranscription/teams/reviewers)).
+- **Approvers** - approve each signing request:
+  [@JuergenFleiss](https://github.com/JuergenFleiss).
+
+## Privacy
+
+aTrain processes recordings and transcripts locally and does not upload them.
+The application transfers data to other systems only in these cases:
+
+- Machine-learning models that are not included in your installation package
+  are downloaded from [Hugging Face](https://huggingface.co/) when a model is
+  first used, or when you download one on the Models page. Hugging Face's
+  [privacy policy](https://huggingface.co/privacy) applies to those requests.
+- Installations from the Microsoft Store are subject to Microsoft's Store
+  telemetry, see the
+  [Microsoft privacy statement](https://privacy.microsoft.com/privacystatement).
+
+aTrain itself sends no usage data or telemetry. The full privacy policy
+(German) is published by the University of Graz:
+<https://business-analytics.uni-graz.at/en/research/atrain/privacy-policy/>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,6 +18,8 @@ source with pip.
 Additional download types are listed on the
 [university download page](https://business-analytics.uni-graz.at/de/forschung/atrain/download/).
 
+How release builds are signed: see the [Code signing policy](code-signing-policy.md).
+
 ## Install from source with pip
 
 You need **Python ≥ 3.11**.


### PR DESCRIPTION
## Summary

SignPath Foundation requires a "Code signing policy" on the project's home and download pages before it issues the production certificate (<https://signpath.org/terms>, "Specify a code signing policy"). This adds it as `docs/code-signing-policy.md` and links it from the README, the installation guide, the docs index and SECURITY.md.

The page covers what is signed per channel (MSIX from GitHub/Zenodo via SignPath from v1.5.0 on, Microsoft Store by Microsoft, Flathub without Authenticode), the team roles, and what the app transmits (model downloads from Hugging Face, Store telemetry, nothing else).

The roles are a proposal taken from the org teams. Adjust as you see fit.

## References

Towards #211.

## Verification Steps

Render `docs/code-signing-policy.md` and follow the four links to it.

cc @gerardo-navarro