### PR TITLE
fix: restore huggingface http_get after a model download

### DIFF
--- a/aTrain_core/load_resources.py
+++ b/aTrain_core/load_resources.py
@@ -32,20 +32,26 @@ def download_all_models():
 
 
 def download_model(model_path: Path, model_info: dict, progress: DictProxy | None = None):
+    # http_get is patched module-wide so the byte progress of every file lands
+    # in one bar. It has to be restored afterwards: the pool worker outlives this
+    # call, and the proxy behind the bar dies with the dialog that opened it.
+    original_http_get = file_download.http_get
     if progress:
-        # Monkey patching custom tqdm bar into the huggingface snapshot download
         repo_size = model_info["repo_size"]
         progress["total"] = repo_size
         tqdm_bar = custom_tqdm(total=repo_size, progress=progress)
-        file_download.http_get = partial(file_download.http_get, _tqdm_bar=tqdm_bar)  # ty: ignore
+        file_download.http_get = partial(original_http_get, _tqdm_bar=tqdm_bar)  # ty: ignore
 
-    snapshot_download(
-        repo_id=model_info["repo_id"],
-        revision=model_info["revision"],
-        local_dir=model_path,
-        local_dir_use_symlinks=False,
-        max_workers=1,
-    )
+    try:
+        snapshot_download(
+            repo_id=model_info["repo_id"],
+            revision=model_info["revision"],
+            local_dir=model_path,
+            local_dir_use_symlinks=False,
+            max_workers=1,
+        )
+    finally:
+        file_download.http_get = original_http_get
 
 
 def get_model(model: str, progress: DictProxy | None = None) -> Path:

--- a/tests/core/test_model_download_in_pool.py
+++ b/tests/core/test_model_download_in_pool.py
@@ -1,0 +1,51 @@
+"""Regression test for the huggingface `http_get` patch in `download_model`.
+
+Mirrors the app's sequence: the Models page downloads a model in a pool worker
+with a progress proxy from a `multiprocessing.Manager`, the manager goes away
+with the dialog, and a later transcription downloads another model in the same
+worker without a progress proxy. Before the fix the worker kept the patched
+`http_get` and wrote to the dead proxy (FileNotFoundError, Windows and Linux
+alike). One worker makes the reuse deterministic; in the app it depends on
+which worker picks up the task, which is why this was intermittent.
+
+Network: downloads tiny (78 MB) and speaker-detection (34 MB) into a fresh
+data dir.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+
+SCRIPT = textwrap.dedent(
+    """
+    from concurrent.futures import ProcessPoolExecutor
+    from multiprocessing import Manager
+
+    from aTrain_core.load_resources import get_model
+
+    if __name__ == "__main__":
+        with ProcessPoolExecutor(max_workers=1) as pool:
+            with Manager() as manager:
+                progress = manager.dict({"current": 0, "total": 999999})
+                pool.submit(get_model, "tiny", progress=progress).result()
+                assert progress["current"] > 0, "progress never reported"
+            # The manager is gone; the worker must not try to reach it again.
+            pool.submit(get_model, "speaker-detection").result()
+        print("second download ok")
+    """
+)
+
+
+def test_second_download_after_a_progress_download_in_the_same_worker(tmp_path):
+    script = tmp_path / "sequence.py"
+    script.write_text(SCRIPT)
+    env = {**os.environ, "ATRAIN_USER_DIR": str(tmp_path / "data")}
+
+    result = subprocess.run(
+        [sys.executable, str(script)], env=env, capture_output=True, text=True, timeout=900
+    )
+
+    assert result.returncode == 0, result.stderr[-3000:]
+    assert "second download ok" in result.stdout
+    assert any(tmp_path.rglob("speaker-detection")), "model did not land in the test data dir"

--- a/tests/unit/test_load_resources.py
+++ b/tests/unit/test_load_resources.py
@@ -1,0 +1,56 @@
+"""Unit tests for aTrain_core/load_resources.py.
+
+`download_model` patches huggingface_hub's `http_get` so the byte progress of a
+download lands in the caller's progress dict. The patch used to stay in place
+for the life of the worker process; the next download in that worker, without
+a progress dict, then wrote to a proxy that was already gone. These tests pin
+the module attribute being restored, with `snapshot_download` stubbed out.
+"""
+
+import pytest
+from aTrain_core import load_resources
+from huggingface_hub import file_download
+
+MODEL_INFO = {"repo_id": "aTrain-core/test", "revision": "abc", "repo_size": 10}
+
+
+@pytest.fixture
+def stub_download(monkeypatch):
+    calls = []
+    monkeypatch.setattr(load_resources, "snapshot_download", lambda **kw: calls.append(kw))
+    return calls
+
+
+def test_http_get_is_restored_after_a_download_with_progress(tmp_path, stub_download):
+    original = file_download.http_get
+    progress = {"current": 0, "total": 999999}
+
+    load_resources.download_model(tmp_path, MODEL_INFO, progress=progress)
+
+    assert file_download.http_get is original
+    assert progress["total"] == 10
+    assert stub_download[0]["local_dir"] == tmp_path
+
+
+def test_http_get_is_restored_when_the_download_fails(tmp_path, monkeypatch):
+    original = file_download.http_get
+
+    def boom(**kw):
+        raise OSError("connection lost")
+
+    monkeypatch.setattr(load_resources, "snapshot_download", boom)
+
+    with pytest.raises(OSError):
+        load_resources.download_model(
+            tmp_path, MODEL_INFO, progress={"current": 0, "total": 999999}
+        )
+
+    assert file_download.http_get is original
+
+
+def test_http_get_is_untouched_without_progress(tmp_path, stub_download):
+    original = file_download.http_get
+
+    load_resources.download_model(tmp_path, MODEL_INFO)
+
+    assert file_download.http_get is original


### PR DESCRIPTION
## Summary

Found while testing v1.5.0-rc2 on Windows: download a model on the Models page, then start a transcription in the same session, and the transcription fails while fetching the speaker-detection model with `FileNotFoundError: [WinError 2]` out of `custom_tqdm.update`.

`download_model` patches `huggingface_hub.file_download.http_get` module-wide with a progress bar bound to the dialog's `DictProxy`, and never restored it. The Models page runs the download in a pool worker, so the patch lived on there; once the dialog's manager was gone, the next `get_model` in that worker, from `transcribe` and without a progress proxy, still went through the patched `http_get` and wrote to the dead proxy. Restarting the app cleared it, and with several pool workers it depended on which one picked up the transcription, so it was intermittent.

Not new code; it became reachable with the slim build (#226), where models are fetched on first use. The fix restores `http_get` in a `finally`.

## References

Refs #226.

## Verification Steps

- `tests/unit/test_load_resources.py`: the module attribute is restored after a download with progress, after a failing download, and untouched without progress. 2 of 3 fail on `develop`.
- `tests/core/test_model_download_in_pool.py`: the real sequence in a one-worker `ProcessPoolExecutor` with a `Manager` proxy that goes away in between, downloading tiny and speaker-detection into a fresh data dir. On `develop` it fails with `FileNotFoundError`, with the fix it passes. Linux and Windows show the same error; the mechanism is the pool worker, not the OS.

cc @gerardo-navarro
